### PR TITLE
fix ObjectUtils.clone()

### DIFF
--- a/sources/utils/ObjectUtils.js
+++ b/sources/utils/ObjectUtils.js
@@ -178,7 +178,7 @@ export function clone( input ) {
         return input.map( value => clone( value ) );
 
     if ( input instanceof ArrayBuffer )
-        return input.slice( );
+        return input.slice( 0 );
 
     var output = { };
 


### PR DESCRIPTION
The [ArrayBuffer spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice) requires a `begin` argument for `ArrayBuffer.prototype.slice()`.

It looks like Chrome implicitly defaults `begin` to `0`, but Safari fails with `TypeError: Slice requires at least one argument`.
